### PR TITLE
Create a new type of query for retrieving max timestamp of all rows under a partition key

### DIFF
--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -205,6 +205,8 @@ K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
+K_MAX:         M A X;
+
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');
 fragment B: ('b'|'B');

--- a/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.ColumnDefinition;
+import org.apache.cassandra.cql3.CFName;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.SingleColumnRelation;
+import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.cql3.Validation;
+import org.apache.cassandra.cql3.VariableSpecifications;
+import org.apache.cassandra.cql3.WhereClause;
+import org.apache.cassandra.cql3.functions.Function;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.cql3.selection.Selection;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionColumns;
+import org.apache.cassandra.db.ReadQuery;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.filter.ClusteringIndexFilter;
+import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
+import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
+import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+/**
+ *
+ * @author Wenfeng Zhuo (wz2366@columbia.edu)
+ * @createAt 01-18-2017
+ */
+public class SelectTimestampStatement implements CQLStatement
+{
+    private static final Logger logger = LoggerFactory.getLogger(SelectTimestampStatement.class);
+
+    public CFMetaData cfm;
+
+    public StatementRestrictions restrictions;
+
+    public SelectTimestampStatement(CFMetaData cfm, StatementRestrictions restrictions) {
+        this.cfm = cfm;
+        this.restrictions = restrictions;
+    }
+
+    public int getBoundTerms()
+    {
+        return 0;
+    }
+
+    public void checkAccess(ClientState state) throws UnauthorizedException, InvalidRequestException
+    {
+
+    }
+
+    public void validate(ClientState state) throws RequestValidationException
+    {
+
+    }
+
+    public ResultMessage execute(QueryState state, QueryOptions options, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
+    {
+        Collection<ByteBuffer> keys = restrictions.getPartitionKeys(options);
+        List<SinglePartitionReadCommand> commands = new ArrayList<>();
+        for (ByteBuffer key : keys) {
+            QueryProcessor.validateKey(key);
+            DecoratedKey decoratedKey = cfm.decorateKey(ByteBufferUtil.clone(key));
+            ClusteringIndexFilter clusteringIndexFilter = new ClusteringIndexNamesFilter(restrictions.getClusteringColumns(options), false);
+            commands.add(SinglePartitionReadCommand.create(cfm, FBUtilities.nowInSeconds(), decoratedKey, ColumnFilter.selectionBuilder().build(), clusteringIndexFilter));
+        }
+        ReadQuery partitionRead = new SinglePartitionReadCommand.Group(commands, DataLimits.NONE);
+
+        try (PartitionIterator data = partitionRead.execute(options.getConsistency(), state.getClientState(), queryStartNanoTime)) {
+            return processResult(data);
+        }
+    }
+
+    private ResultMessage processResult(PartitionIterator data) {
+        long maxTimestamp = Long.MIN_VALUE;
+        while (data.hasNext()) {
+            RowIterator rows = data.next();
+            while (rows.hasNext()) {
+                Row row = rows.next();
+                maxTimestamp = Math.max(maxTimestamp, row.primaryKeyLivenessInfo().timestamp());
+            }
+        }
+        List<ColumnSpecification> colums = Arrays.asList(new ColumnSpecification(cfm.ksName, cfm.cfName, new ColumnIdentifier("timestamp", false), LongType.instance));
+        ResultSet resultSet = new ResultSet(colums);
+        resultSet.addRow(Arrays.asList(ByteBufferUtil.bytes(maxTimestamp)));
+        return new ResultMessage.Rows(resultSet);
+    }
+
+    public ResultMessage executeInternal(QueryState state, QueryOptions options) throws RequestValidationException, RequestExecutionException
+    {
+        return execute(state, options, System.nanoTime());
+    }
+
+    public Iterable<Function> getFunctions()
+    {
+        return new ArrayList<>();
+    }
+
+    public static class RawStatement extends CFStatement
+    {
+
+        public List<Term.Raw> values;
+
+        public RawStatement(CFName cfName, List<Term.Raw> values)
+        {
+            super(cfName);
+            this.values = values;
+        }
+
+        public Prepared prepare() throws RequestValidationException
+        {
+            CFMetaData cfm = Validation.validateColumnFamily(keyspace(), columnFamily());
+            VariableSpecifications boundNames = getBoundVariables();
+
+            WhereClause.Builder whereClause = new WhereClause.Builder();
+
+            List<ColumnDefinition> partitionKeys = cfm.partitionKeyColumns();
+            for (int i = 0; i < values.size(); i ++) {
+                whereClause.add(
+                    new SingleColumnRelation(
+                        ColumnDefinition.Raw.forColumn(partitionKeys.get(i)),
+                        Operator.EQ,
+                        values.get(i)
+                    )
+                );
+            }
+
+            StatementRestrictions restrictions = new StatementRestrictions(StatementType.SELECT,
+                                                                           cfm,
+                                                                           whereClause.build(),
+                                                                           boundNames,
+                                                                           false,
+                                                                           false,
+                                                                           false);
+            SelectTimestampStatement stmt = new SelectTimestampStatement(cfm, restrictions);
+            return new ParsedStatement.Prepared(stmt);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
@@ -165,7 +165,7 @@ public class SelectTimestampStatement implements CQLStatement
     }
 
     /**
-     * Get ReadQuery from restrictions. The ReadQuery will created as a SinglePartitionReadCommand.
+     * Get ReadQuery from restrictions. The ReadQuery will created as a PartitionRangeReadCommand.
      * @param options
      * @return
      */

--- a/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectTimestampStatement.java
@@ -85,6 +85,10 @@ import org.apache.cassandra.utils.FBUtilities;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 
 /**
+ * Statement that represents the query of the max timestamp of all rows under a partition key.
+ *
+ * The statement will have the following format:
+ * "SELECT MAX TIMESTAMP <Table Name>(<part one of partition key>, <part two of partition key>, ...)"
  *
  * @author Wenfeng Zhuo (wz2366@columbia.edu)
  * @createAt 01-18-2017
@@ -101,6 +105,7 @@ public class SelectTimestampStatement implements CQLStatement
 
     public StatementRestrictions restrictions;
 
+    // The column "timestamp" for query result
     private List<ColumnSpecification> columns;
 
     public SelectTimestampStatement(CFMetaData cfm, int boundTerms, StatementRestrictions restrictions) {
@@ -264,7 +269,7 @@ public class SelectTimestampStatement implements CQLStatement
             WhereClause.Builder whereClause = new WhereClause.Builder();
 
             List<ColumnDefinition> partitionKeys = cfm.partitionKeyColumns();
-            checkTrue(partitionKeys.size() == values.size(), "The number of values for partition keys does not match the table definition");
+            checkTrue(partitionKeys.size() == values.size(), "The number of values for partition key does not match the table definition");
 
             for (int i = 0; i < values.size(); i ++) {
                 whereClause.add(

--- a/test/unit/org/apache/cassandra/cql3/statements/SelectTimestampStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/SelectTimestampStatementTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+
+/**
+ * @author Wenfeng Zhuo (wz2366@columbia.edu)
+ * @createAt 01-18-2017
+ */
+public class SelectTimestampStatementTest extends CQLTester
+{
+
+    @Test
+    public void testOnSinglePartitionKey() throws Throwable
+    {
+        int size = 10;
+
+        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+        long expectedMaxTimestamp = Long.MIN_VALUE;
+        Random r = new Random();
+        for (int i = 0; i < size; i ++) {
+            long timestamp = r.nextLong();
+            timestamp = timestamp < 0 ? -(timestamp + 1) : timestamp;
+            expectedMaxTimestamp = Math.max(expectedMaxTimestamp, timestamp);
+            execute("INSERT INTO %s (k, t, v) values (?, ?, ?) USING TIMESTAMP ?", "key", i, "v11", timestamp);
+        }
+
+        flush();
+
+        assertRows(execute("SELECT MAX TIMESTAMP %s (?)", "key"),
+            row(expectedMaxTimestamp)
+        );
+    }
+
+    @Test
+    public void testOnMultiplePartitionKeys() throws Throwable
+    {
+        int size = 10;
+
+        String key = "key";
+        int t = 0;
+
+        createTable("CREATE TABLE %s (k1 text, k2 int, v text, PRIMARY KEY ((k1, k2)));");
+
+        long expectedMaxTimestamp = Long.MIN_VALUE;
+        Random r = new Random();
+        for (int i = 0; i < size; i ++) {
+            long timestamp = r.nextLong();
+            timestamp = timestamp < 0 ? -(timestamp + 1) : timestamp;
+            expectedMaxTimestamp = Math.max(expectedMaxTimestamp, timestamp);
+            execute("INSERT INTO %s (k1, k2, v) values (?, ?, ?) USING TIMESTAMP ?", key, t, "v11", timestamp);
+        }
+
+        flush();
+
+        assertRows(execute("SELECT MAX TIMESTAMP %s (?, ?)", key, t),
+            row(expectedMaxTimestamp)
+        );
+    }
+
+    @Test
+    public void testOnNoResultReturned() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k1 text, t int, v text, PRIMARY KEY (k1));");
+
+        assertEmpty(execute("SELECT MAX TIMESTAMP %s (?)", "key"));
+    }
+
+}


### PR DESCRIPTION
This patch implemented a new type of query that supports query of max timestamp of all rows under a partition key. The following picture shows how to use this new type of query:

The picture shows four scenarios for this query.

- query the max timestamp for a partition key (the key is single)
- query the max timestamp for a partition key (the key is composite)
- query the max timestamp for a non-exist key (will return a empty result)
- query the max timestamp with insufficient number of values for partition key (will raise an error)

![pic](http://i.imgur.com/vo5FW4g.gif)

The solution created a new grammar in CQL and an independent statement. It uses built-in ReadCommand to read all rows, so it follows the same path with SelectStatement. The difference is that it does not require any columns to be returned, which could help to reduce much I/O operations. As the data is offered online, so every row will be read at least once, hence the time complexity for this query will be O(n) (n represents the number of rows in this partition key). As much less data is returned, it will not cause much consumption of memory. Hence, both time complexity and memory complexity will satisfy the requirements.

As for the shortage of this implementation, it uses built-in ReadCommand to read the data, although all the data we need is the metadata of those rows. As the max timestamp is for a partition key, we could maintain a "max timestamp" metadata item for each partition key. When inserting, updating or deleting a row under this partition key, we directly update its "max timestamp". In this way, we could retrieve the max timestamp in O(1) time. But for this solution, it requires extra efforts to make sure the max timestamp is updated correctly due to concurrency, which might cause performance issue. If this is a used heavily by users, then we could implement a more efficient solution otherwise the former solution will be preferred as above described trade-offs.